### PR TITLE
CVE updates

### DIFF
--- a/cves/CVE-2023-36792.yaml
+++ b/cves/CVE-2023-36792.yaml
@@ -1,0 +1,11 @@
+affectedPackages:
+  - cpe23Uri: cpe:2.3:a:microsoft:microsoft.netcore.app:*:*:*:*:*:*:*:*
+    versionEndExcluding: 6.0.22
+    versionStartIncluding: 6.0.0
+    vulnerable: true
+  - cpe23Uri: cpe:2.3:a:microsoft:microsoft.netcore.app:*:*:*:*:*:*:*:*
+    versionEndExcluding: 7.0.11
+    versionStartIncluding: 7.0.0
+    vulnerable: true
+id: CVE-2023-36792
+link: https://github.com/dotnet/announcements/issues/271

--- a/cves/CVE-2023-36793.yaml
+++ b/cves/CVE-2023-36793.yaml
@@ -1,0 +1,11 @@
+affectedPackages:
+  - cpe23Uri: cpe:2.3:a:microsoft:microsoft.netcore.app:*:*:*:*:*:*:*:*
+    versionEndExcluding: 6.0.22
+    versionStartIncluding: 6.0.0
+    vulnerable: true
+  - cpe23Uri: cpe:2.3:a:microsoft:microsoft.netcore.app:*:*:*:*:*:*:*:*
+    versionEndExcluding: 7.0.11
+    versionStartIncluding: 7.0.0
+    vulnerable: true
+id: CVE-2023-36793
+link: https://github.com/dotnet/announcements/issues/273

--- a/cves/CVE-2023-36796.yaml
+++ b/cves/CVE-2023-36796.yaml
@@ -1,0 +1,11 @@
+affectedPackages:
+  - cpe23Uri: cpe:2.3:a:microsoft:microsoft.netcore.app:*:*:*:*:*:*:*:*
+    versionEndExcluding: 6.0.22
+    versionStartIncluding: 6.0.0
+    vulnerable: true
+  - cpe23Uri: cpe:2.3:a:microsoft:microsoft.netcore.app:*:*:*:*:*:*:*:*
+    versionEndExcluding: 7.0.11
+    versionStartIncluding: 7.0.0
+    vulnerable: true
+id: CVE-2023-36796
+link: https://github.com/dotnet/announcements/issues/274


### PR DESCRIPTION
The [GH action](https://github.com/stackrox/dotnet-scraper/actions/runs/6179147627/job/16773600140) reported that the following announcements were not accounted for:

```
2023/09/14 00:11:56 Unaccounted for issue: https://github.com/dotnet/announcements/issues/273
2023/09/14 00:11:56 Unaccounted for issue: https://github.com/dotnet/announcements/issues/271
2023/09/14 00:11:56 Unaccounted for issue: https://github.com/dotnet/announcements/issues/274
```
This PR adds the relevant CVEs