### PR TITLE
CVE Updates

### DIFF
--- a/cves/CVE-2023-36435.yaml
+++ b/cves/CVE-2023-36435.yaml
@@ -1,0 +1,7 @@
+affectedPackages:
+  - cpe23Uri: cpe:2.3:a:microsoft:microsoft.netcore.app:*:*:*:*:*:*:*:*
+    versionStartIncluding: 7.0.0
+    versionEndIncluding: 7.0.11
+    vulnerable: true
+id: CVE-2023-36435
+link: https://github.com/dotnet/announcements/issues/278

--- a/cves/CVE-2023-38171.yaml
+++ b/cves/CVE-2023-38171.yaml
@@ -1,0 +1,7 @@
+affectedPackages:
+  - cpe23Uri: cpe:2.3:a:microsoft:microsoft.netcore.app:*:*:*:*:*:*:*:*
+    versionStartIncluding: 7.0.0
+    versionEndIncluding: 7.0.11
+    vulnerable: true
+id: CVE-2023-38171
+link: https://github.com/dotnet/announcements/issues/279


### PR DESCRIPTION
The [GH action](https://github.com/stackrox/dotnet-scraper/actions/runs/6486244418/job/17614043523) reported that the following announcements were not accounted for:

```
2023/10/11 18:09:38 Unaccounted for issue: https://github.com/dotnet/announcements/issues/278
2023/10/11 18:09:38 Unaccounted for issue: https://github.com/dotnet/announcements/issues/279
```
This PR adds the relevant metadata