### PR TITLE
Address CVE-2023-36038

### DIFF
--- a/croncheck/main.go
+++ b/croncheck/main.go
@@ -124,7 +124,7 @@ var knownMissingLinks = []string{
 
 	// Only affects release candidates for .NET 8.0, ACS Scanner's analyzer currently
 	// ignores release candidate versions.  More info here:
-	// https://github.com/stackrox/scanner/blob/0811d631da3eb0f7bb0893d62859629a484ac023/pkg/analyzer/dotnetcoreruntime/analyzer.go#L28
+	// https://github.com/stackrox/dotnet-scraper/pull/38#pullrequestreview-1700612216
 	"https://github.com/dotnet/announcements/issues/286",
 }
 

--- a/croncheck/main.go
+++ b/croncheck/main.go
@@ -121,6 +121,11 @@ var knownMissingLinks = []string{
 
 	// Duplicate of https://github.com/dotnet/announcements/issues/280
 	"https://github.com/dotnet/announcements/issues/279",
+
+	// Only affects release candidates for .NET 8.0, ACS Scanner's analyzer currently
+	// ignores release candidate versions.  More info here:
+	// https://github.com/stackrox/scanner/blob/0811d631da3eb0f7bb0893d62859629a484ac023/pkg/analyzer/dotnetcoreruntime/analyzer.go#L28
+	"https://github.com/dotnet/announcements/issues/286",
 }
 
 type linkRef struct {


### PR DESCRIPTION
Per the [advisory](https://github.com/dotnet/announcements/issues/286) this CVE affects release candidates of .NET 8.0.

The current scanner analyzer will ignore release candidate versions, [context](https://github.com/stackrox/dotnet-scraper/pull/38#pullrequestreview-1700612216), - since the current scanner is being deprecated, this CVE will be ignored.