### PR TITLE
chore: disable cron job

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,8 +1,6 @@
 name: Cron
 
-on:
-  schedule:
-    - cron: "0 */6 * * *"
+on: workflow_dispatch
 
 jobs:
   build:


### PR DESCRIPTION
Temporarily disable the croncheck job. We intend to revert this commit after the holiday break.